### PR TITLE
Increase phar build speed

### DIFF
--- a/bin/phar-install
+++ b/bin/phar-install
@@ -25,17 +25,8 @@ $tmp = getenv('TMP_FILE');
 
 $phar = new Phar($tmp);
 
-$di = new RecursiveDirectoryIterator('vendor');
-foreach (new RecursiveIteratorIterator($di) as $filename => $file) {
-  if (
-    preg_match('_/\.\.?$_', $filename) || # .. and .
-    preg_match('_/\.git/_', $filename)    # .git
-  ) {
-    continue;
-  }
-  echo "Adding file: $filename\n";
-  $phar->addFile($filename);
-}
+echo 'Building phar file files' . PHP_EOL;
+$phar->buildFromDirectory('./', '_(?!.*\/\.git\/)_'); //not sure if this regex is correct to filter out all .git folders
 
 $rand = sprintf('%x', mt_rand());
 


### PR DESCRIPTION
Use Phar::builfFromDirectory() to greatly increase build speed. Phar build now takes seconds instead of 10's of minutes.